### PR TITLE
[design] Repositionate Comment Icons

### DIFF
--- a/static/css/commentIcon.css
+++ b/static/css/commentIcon.css
@@ -7,7 +7,7 @@
 
 /* when line numbers are not visible, we need to move icons to the left */
 #sidediv.sidedivhidden ~ #commentIcons {
-  padding-left: 0px;
+  padding-left: 20px;
 }
 
 /* when page view is disabled, we need to move icons to the left */
@@ -29,14 +29,14 @@
 .comment-icon {
   display: inline-block;
   margin-right: 5px;
-  fill: #808286;
+  fill: #808286; /* Color 130 */
   cursor: pointer;
 }
 .comment-icon:hover {
-  fill: #515256;
+  fill: #515256; /* Color 80 */
 }
 .comment-icon.active {
-  fill: #19BBDA;
+  fill: #19BBDA; /* Color A */
 }
 
 /* show the single-comment icon by default */

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -250,7 +250,7 @@ var adjustTopOf = function(commentId, baseTop) {
   if (!displayIcons() || !screenHasSpaceForIcons()) return;
 
   var icon = utils.getPadOuter().find('#icon-'+commentId);
-  var targetTop = baseTop+5;
+  var targetTop = baseTop+2;
   var iconsAtLine = getOrCreateIconsContainerAt(targetTop);
 
   // move icon from one line to the other


### PR DESCRIPTION
Os ícones de comentário estavam se sobrepondo ao ícone de informações das SM.
Os joguei mais para a direita e os subi um pouco, para alinhá-los a linha referente.
Também adicionei comentários nomeando cores hexadecimais.