### PR TITLE
[refactor] Enable this plugin to be used to process copy/cut/paste of other plugins

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -12,7 +12,7 @@ var EDIT_COMMENT_MESSAGE_TYPE = 'comment_edit';
 var EDIT_REPLY_MESSAGE_TYPE = 'comment_reply_edit';
 var DELETE_REPLY_MESSAGE_TYPE = 'comment_reply_delete';
 
-exports.initialize = function() {
+exports.init = function() {
   // listen to outbound calls of this API
   window.addEventListener('message', function(e) {
     _handleOutboundCalls(e);

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,241 +1,48 @@
-var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 var _ = require('ep_etherpad-lite/static/js/underscore');
-var shared = require('./shared');
 var utils = require('./utils');
+var copyPasteHelper = require('./copyPasteHelper');
+var htmlExtractor = require('./htmlExtractorFromSelection');
 
-exports.addTextOnClipboard = function(e, ace, removeSelection, comments) {
-  var hasCommentOnSelection;
-  ace.callWithAce(function(ace) {
-    hasCommentOnSelection = ace.ace_hasCommentOnSelection();
+var addTextAndDataOfAllHelpersToClipboardAndDeleteSelectedContent = function(e) {
+  addTextAndDataOfAllHelpersToClipboard(e);
+  utils.getPadInner().get(0).execCommand('delete');
+}
+
+var addTextAndDataOfAllHelpersToClipboard = function(e) {
+  var $copiedHtml = htmlExtractor.getHtmlOfSelectedContent();
+  var clipboardData = e.originalEvent.clipboardData;
+
+  var helpersHaveItemsOnSelection = _(pad.copyPasteHelpers).map(function(helper) {
+    return helper.addTextAndDataToClipboard(clipboardData, $copiedHtml);
   });
 
-  if(hasCommentOnSelection){
-    var range = utils.getPadInner()[0].getSelection().getRangeAt(0);
-    var $copiedHtml = createHiddenDiv(range);
-    var onlyTextIsSelected = selectionHasOnlyText($copiedHtml);
-
-    // when the range selection is fully inside a tag, '$copiedHtml' will have no HTML tag, so we have to
-    // build it. Ex: if we have '<span>ab<b>cdef</b>gh</span>" and user selects 'de', the value of
-    // '$copiedHtml' will be 'de', not '<b>de</b>'
-    if (onlyTextIsSelected) {
-      var textSelected = $copiedHtml[0].textContent;
-      $copiedHtml = buildHtmlToCopyWhenSelectionHasOnlyText(textSelected, range);
-    }
-
-    var replies = utils.getRepliesIndexedByReplyId(comments);
-    var commentsData = buildCommentsDataWithNewCommentIds($copiedHtml, comments);
-    var replyData = buildRepliesDataWithNewCommentIds($copiedHtml, replies);
-    var commentsJSON = JSON.stringify(commentsData);
-    var replyJSON = JSON.stringify(replyData);
-    e.originalEvent.clipboardData.setData('text/objectComment', commentsJSON);
-    e.originalEvent.clipboardData.setData('text/objectReply', replyJSON);
-
-    // here we override the default copy behavior
-    e.originalEvent.clipboardData.setData('text/html', $copiedHtml.html());
+  var atLeastOneItemChangedClipboard = _(helpersHaveItemsOnSelection).any();
+  if (atLeastOneItemChangedClipboard) {
+    // override the default copy behavior
+    clipboardData.setData('text/html', $copiedHtml.html());
     e.preventDefault();
-
-    // if it is a cut event we have to remove the selection
-    if(removeSelection){
-      utils.getPadInner()[0].execCommand('delete');
-    }
   }
-};
-
-var buildCommentsDataWithNewCommentIds = function($copiedHtml, comments){
-  var commentsData = {};
-  var originalCommentIds = getCommentIds($copiedHtml);
-
-  _.each(originalCommentIds, function(originalCommentId){
-    var newCommentId = shared.generateCommentId();
-
-    // replace comment id on comment db data
-    var comment = Object.assign({}, comments[originalCommentId]);
-    comment.commentId = newCommentId;
-    commentsData[newCommentId] = comment;
-
-    // replace comment id on reply db data
-    _.each(comment.replies, function(reply) {
-      reply.commentId = newCommentId;
-    });
-
-    // replace comment id on pad content
-    $copiedHtml.find('.' + originalCommentId).removeClass(originalCommentId).addClass(newCommentId);
-  });
-
-  return commentsData;
-};
-
-var buildRepliesDataWithNewCommentIds = function($copiedHtml, replies){
-  var repliesData = {};
-  var originalReplyIds = getReplyIds($copiedHtml);
-
-  _.each(originalReplyIds, function(originalReplyId){
-    var newReplyId = shared.generateReplyId();
-
-    // replace comment id on comment db data
-    var reply = Object.assign({}, replies[originalReplyId]);
-    reply.replyId = newReplyId;
-    repliesData[newReplyId] = reply;
-
-    // replace reply id on pad content
-    $copiedHtml.find('.' + originalReplyId).removeClass(originalReplyId).addClass(newReplyId);
-  });
-
-  return repliesData;
-};
-
-var getCommentIds = function($copiedHtml){
-  var $allComments = $copiedHtml.find('span.comment');
-  var commentIds = $allComments.map(function(){
-    var cls = $(this).attr('class');
-    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
-    var commentId = (classCommentId) ? classCommentId[1] : false;
-    return commentId;
-  });
-  commentIds = _.compact(commentIds);
-  commentIds = _.uniq(commentIds);
-  return commentIds;
-};
-
-var getReplyIds = function($copiedHtml){
-  var $allReplies = $copiedHtml.find('span.comment-reply');
-  var replyIds = $allReplies.map(function(){
-    var cls = $(this).attr('class');
-    var classReplyId = /(?:^| )(cr-[A-Za-z0-9]*)/.exec(cls);
-    var replyId = (classReplyId) ? classReplyId[1] : false;
-    return replyId;
-  });
-  replyIds = _.compact(replyIds);
-  replyIds = _.uniq(replyIds);
-  return replyIds;
-};
-
-var createHiddenDiv = function(range){
-  var content = range.cloneContents();
-  var div = document.createElement("div");
-  var hiddenDiv = $(div).html(content);
-  return hiddenDiv;
-};
-
-var selectionHasOnlyText = function($copiedHtml){
-  var html = $copiedHtml.html();
-  var htmlDecoded = htmlDecode(html);
-  var text = $copiedHtml.text();
-  return htmlDecoded === text;
-};
-
-// copied from https://css-tricks.com/snippets/javascript/unescape-html-in-js/
-var htmlDecode = function(input) {
-  var e = document.createElement('div');
-  e.innerHTML = input;
-  return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
-};
-
-var buildHtmlToCopyWhenSelectionHasOnlyText = function(text, range) {
-  var htmlTemplate = getHtmlTemplateWithAllTagsOfSelectedContent(range);
-  return splitSelectedTextIntoTwoSpans(text, htmlTemplate);
-};
-
-var getHtmlTemplateWithAllTagsOfSelectedContent = function(range) {
-  // '.addBack': selected text might be a direct child of the comment span
-  var $commentSpanWithSelectedContent = $(range.commonAncestorContainer).parentsUntil('.comment').addBack().first().parent();
-  return $commentSpanWithSelectedContent.get(0).outerHTML;
 }
 
-// FIXME - Allow to copy a comment when user copies only one char
-// This is a hack to preserve the comment classes when user pastes a comment. When user pastes a span like this
-// <span class='comment c-124'>thing</span>, chrome removes the classes and keeps only the style of the class. With comments
-// chrome keeps the background-color. To avoid this we create two spans. The first one, <span class='comment c-124'>thi</span>
-// has the text until the last but one character and second one with the last character <span class='comment c-124'>g</span>.
-// Etherpad does a good job joining the two spans into one after the paste is triggered.
-var splitSelectedTextIntoTwoSpans = function(text, commentSpanTemplate) {
-  var $firstSpan = $(commentSpanTemplate);
-  var $secondSpan = $(commentSpanTemplate);
-
-  // '.find('*').last()': need to set text on the deepest tag
-  $firstSpan.find('*').last().text(text.slice(0, -1)); // text until before last char
-  $secondSpan.find('*').last().text(text.slice(-1)); // last char
-
-  return $('<span>' + $firstSpan.get(0).outerHTML + $secondSpan.get(0).outerHTML + '</span>');
+var saveItemsAndSubItemsOfAllHelpers = function(e) {
+  var clipboardData = e.originalEvent.clipboardData;
+  _(pad.copyPasteHelpers).each(function(helper) {
+    helper.saveItemsAndSubItems(clipboardData);
+  });
 }
 
-exports.saveCommentsAndReplies = function(e){
-  var comments = e.originalEvent.clipboardData.getData('text/objectComment');
-  var replies = e.originalEvent.clipboardData.getData('text/objectReply');
-
-  if(comments && replies) {
-    pad.plugins.ep_comments_page.saveCommentWithoutSelection(JSON.parse(comments));
-    pad.plugins.ep_comments_page.saveRepliesWithoutSelection(JSON.parse(replies));
+exports.init = function() {
+  // Override  copy, cut, paste events on Google chrome and Mozilla Firefox.
+  if(browser.chrome || browser.firefox) {
+    utils.getPadInner().
+    on('copy' , addTextAndDataOfAllHelpersToClipboard).
+    on('cut'  , addTextAndDataOfAllHelpersToClipboardAndDeleteSelectedContent).
+    on('paste', saveItemsAndSubItemsOfAllHelpers);
   }
-};
-
-exports.hasCommentOnSelection = function() {
-  var hasComment;
-  var attributeManager = this.documentAttributeManager;
-  var rep = this.rep;
-  var firstLineOfSelection = rep.selStart[0];
-  var firstColumn = rep.selStart[1];
-  var lastColumn = rep.selEnd[1];
-  var lastLineOfSelection = rep.selEnd[0];
-  var selectionOfMultipleLine = hasMultipleLineSelected(firstLineOfSelection, lastLineOfSelection);
-
-  if(selectionOfMultipleLine){
-    hasComment = hasCommentOnMultipleLineSelection(firstLineOfSelection,lastLineOfSelection, rep, attributeManager);
-  }else{
-    hasComment = hasCommentOnLine(firstLineOfSelection, firstColumn, lastColumn, attributeManager)
-  }
-  return hasComment;
-};
-
-var hasCommentOnMultipleLineSelection = function(firstLineOfSelection, lastLineOfSelection, rep, attributeManager){
-  var foundLineWithComment = false;
-  for (var line = firstLineOfSelection; line <= lastLineOfSelection && !foundLineWithComment; line++) {
-    var firstColumn = getFirstColumnOfSelection(line, rep, firstLineOfSelection);
-    var lastColumn = getLastColumnOfSelection(line, rep, lastLineOfSelection);
-    var hasComment = hasCommentOnLine(line, firstColumn, lastColumn, attributeManager);
-    if (hasComment){
-      foundLineWithComment = true;
-    }
-  }
-  return foundLineWithComment;
 }
 
-var getFirstColumnOfSelection = function(line, rep, firstLineOfSelection){
-  return line !== firstLineOfSelection ? 0 : rep.selStart[1];
-};
-
-var getLastColumnOfSelection = function(line, rep, lastLineOfSelection){
-  var lastColumnOfSelection;
-  if (line !== lastLineOfSelection) {
-    lastColumnOfSelection = getLength(line, rep); // length of line
-  }else{
-    lastColumnOfSelection = rep.selEnd[1] - 1; //position of last character selected
-  }
-  return lastColumnOfSelection;
-};
-
-var hasCommentOnLine = function(lineNumber, firstColumn, lastColumn, attributeManager){
-  var foundCommentOnLine = false;
-  for (var column = firstColumn; column <= lastColumn && !foundCommentOnLine; column++) {
-    var commentId = _.object(attributeManager.getAttributesOnPosition(lineNumber, column)).comment;
-    if (commentId !== undefined){
-      foundCommentOnLine = true;
-    }
-  }
-  return foundCommentOnLine;
-};
-
-var hasMultipleLineSelected = function(firstLineOfSelection, lastLineOfSelection){
-  return  firstLineOfSelection !== lastLineOfSelection;
-};
-
-var getLength = function(line, rep) {
-  var nextLine = line + 1;
-  var startLineOffset = rep.lines.offsetOfIndex(line);
-  var endLineOffset   = rep.lines.offsetOfIndex(nextLine);
-
-  //lineLength without \n
-  var lineLength = endLineOffset - startLineOffset - 1;
-
-  return lineLength;
-};
+exports.listenToCopyCutPasteEventsOfItems = function(configs) {
+  var helper = copyPasteHelper.init(configs);
+  pad.copyPasteHelpers = pad.copyPasteHelpers || [];
+  pad.copyPasteHelpers.push(helper)
+}

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,6 +1,7 @@
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var utils = require('./utils');
 var copyPasteHelper = require('./copyPasteHelper');
+var fakeIdsMapper = require('./copyPasteFakeIdsMapper');
 var htmlExtractor = require('./htmlExtractorFromSelection');
 
 var addTextAndDataOfAllHelpersToClipboardAndDeleteSelectedContent = function(e) {
@@ -12,7 +13,7 @@ var addTextAndDataOfAllHelpersToClipboard = function(e) {
   var $copiedHtml = htmlExtractor.getHtmlOfSelectedContent();
   var clipboardData = e.originalEvent.clipboardData;
 
-  var helpersHaveItemsOnSelection = _(pad.copyPasteHelpers).map(function(helper) {
+  var helpersHaveItemsOnSelection = _(pad.plugins.ep_comments_page.copyPasteHelpers).map(function(helper) {
     return helper.addTextAndDataToClipboard(clipboardData, $copiedHtml);
   });
 
@@ -26,12 +27,17 @@ var addTextAndDataOfAllHelpersToClipboard = function(e) {
 
 var saveItemsAndSubItemsOfAllHelpers = function(e) {
   var clipboardData = e.originalEvent.clipboardData;
-  _(pad.copyPasteHelpers).each(function(helper) {
+  _(pad.plugins.ep_comments_page.copyPasteHelpers).each(function(helper) {
     helper.saveItemsAndSubItems(clipboardData);
   });
 }
 
 exports.init = function() {
+  pad.plugins = pad.plugins || {};
+  pad.plugins.ep_comments_page = pad.plugins.ep_comments_page || {};
+  pad.plugins.ep_comments_page.copyPasteHelpers = pad.plugins.ep_comments_page.copyPasteHelpers || [];
+  pad.plugins.ep_comments_page.fakeIdsMapper = fakeIdsMapper.init();
+
   // Override  copy, cut, paste events on Google chrome and Mozilla Firefox.
   if(browser.chrome || browser.firefox) {
     utils.getPadInner().
@@ -43,6 +49,5 @@ exports.init = function() {
 
 exports.listenToCopyCutPasteEventsOfItems = function(configs) {
   var helper = copyPasteHelper.init(configs);
-  pad.copyPasteHelpers = pad.copyPasteHelpers || [];
-  pad.copyPasteHelpers.push(helper)
+  pad.plugins.ep_comments_page.copyPasteHelpers.push(helper)
 }

--- a/static/js/copyPasteFakeIdsMapper.js
+++ b/static/js/copyPasteFakeIdsMapper.js
@@ -1,0 +1,15 @@
+var copyPasteFakeIdsMapper = function() {
+  this.fakeIdToRealIdMap = {};
+};
+
+copyPasteFakeIdsMapper.prototype.registerNewMapping = function(fakeId, realId) {
+  this.fakeIdToRealIdMap[fakeId] = realId;
+}
+
+copyPasteFakeIdsMapper.prototype.getRealIdOfFakeId = function(fakeId) {
+  return this.fakeIdToRealIdMap[fakeId];
+}
+
+exports.init = function() {
+  return new copyPasteFakeIdsMapper();
+}

--- a/static/js/copyPasteHelper.js
+++ b/static/js/copyPasteHelper.js
@@ -161,7 +161,7 @@ copyPasteHelper.prototype._replaceFakeIdsWithNewIds = function(itemsWithFakeIds,
   var itemsWithNewIds = {};
 
   _(itemsWithFakeIds).each(function(itemWithFakeId, originaFakeId) {
-    var newId = generateNewId();
+    var newId = generateNewId(itemWithFakeId);
     var itemWithNewId = this._replaceIdOnItemAndSubItems(itemWithFakeId, newId, setItemIdOnItem, updateSubItemsToo);
     itemsWithNewIds[newId] = itemWithNewId;
 

--- a/static/js/copyPasteHelper.js
+++ b/static/js/copyPasteHelper.js
@@ -1,0 +1,148 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var _ = require('ep_etherpad-lite/static/js/underscore');
+
+var copyPasteHelper = function() {};
+
+copyPasteHelper.prototype.addTextAndDataToClipboard = function(clipboardData, $copiedHtml) {
+  var hasItemsOnSelection = $copiedHtml.find(this.itemSelectorOnPad).length > 0;
+  if (hasItemsOnSelection) {
+    var items = this.getItemsData();
+    this._buildDataAndSaveToClipboard(clipboardData, $copiedHtml, items, this.itemType, this._buildItemsDataWithNewIds.bind(this));
+
+    if (this._itemHasSubItems()) {
+      var subItems = this.getSubItemsData(items);
+      this._buildDataAndSaveToClipboard(clipboardData, $copiedHtml, subItems, this.subItemType, this._buildSubItemsDataWithNewIds.bind(this));
+    }
+  }
+  return hasItemsOnSelection;
+}
+
+copyPasteHelper.prototype._buildDataAndSaveToClipboard = function(clipboardData, $copiedHtml, items, itemType, buildItemsDataWithNewIds) {
+  var itemsWithNewIds = buildItemsDataWithNewIds($copiedHtml, items);
+  var itemsJSON = JSON.stringify(itemsWithNewIds);
+  var itemDataTypeOnClipboard = this._getClipboardDataTypeOf(itemType);
+  clipboardData.setData(itemDataTypeOnClipboard, itemsJSON);
+}
+
+copyPasteHelper.prototype._buildSubItemsDataWithNewIds = function($copiedHtml, subItems) {
+  return this._buildDataWithNewIds(
+    $copiedHtml,
+    subItems,
+    this._getSubItemIdsFrom.bind(this),
+    this.generateNewSubItemId,
+    this.setSubItemIdOnSubItem,
+  );
+}
+
+copyPasteHelper.prototype._buildItemsDataWithNewIds = function($copiedHtml, items) {
+  return this._buildDataWithNewIds(
+    $copiedHtml,
+    items,
+    this._getItemIdsFrom.bind(this),
+    this.generateNewItemId,
+    this.setItemIdOnItem,
+    this.setItemIdOnSubItem,
+    this.getSubItemsOf,
+  );
+}
+
+copyPasteHelper.prototype._buildDataWithNewIds = function($copiedHtml, items, getIdsFromHtml, generateNewId, setItemIdOnItem, setItemIdOnSubItem, getSubItemsOf) {
+  var itemsWithNewIds = {};
+  var originalIds = getIdsFromHtml($copiedHtml);
+
+  _.each(originalIds, function(originaId) {
+    var newId = generateNewId();
+
+    // create a copy of item with new id
+    var itemWithNewId = Object.assign({}, items[originaId]);
+    itemsWithNewIds[newId] = itemWithNewId;
+    setItemIdOnItem(itemWithNewId, newId);
+
+    var updateSubItemsToo = setItemIdOnSubItem && getSubItemsOf;
+    if (updateSubItemsToo) {
+      // replace item id on its sub-items
+      var subItems = getSubItemsOf(itemWithNewId);
+      _.each(subItems, function(subItem) {
+        setItemIdOnSubItem(subItem, newId);
+      });
+    }
+
+    // replace item id on pad content
+    $copiedHtml.find('.' + originaId).removeClass(originaId).addClass(newId);
+  });
+
+  return itemsWithNewIds;
+}
+
+copyPasteHelper.prototype._getItemIdsFrom = function($copiedHtml) {
+  return this._getIdsFrom($copiedHtml, this.itemSelectorOnPad, this.getItemIdsFromString);
+}
+copyPasteHelper.prototype._getSubItemIdsFrom = function($copiedHtml) {
+  return this._getIdsFrom($copiedHtml, this.subItemSelectorOnPad, this.getSubItemIdsFromString);
+}
+
+copyPasteHelper.prototype._getIdsFrom = function($copiedHtml, selectorOnPad, getIdFromString) {
+  var $copiedItemsOrSubItems = $copiedHtml.find(selectorOnPad);
+  return _($copiedItemsOrSubItems)
+    .chain()
+    // extract item/sub-item ids from their classes
+    .map(function(copiedItem) {
+      var cls = $(copiedItem).attr('class');
+      return getIdFromString(cls);
+    })
+    .flatten()
+    .compact()
+    .unique()
+    .value();
+}
+
+copyPasteHelper.prototype._capitalizeFirstChar = function(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+copyPasteHelper.prototype.saveItemsAndSubItems = function(clipboardData) {
+  this._getClipboardDataAndSaveIt(clipboardData, this.itemType, this.saveItemsData);
+  if (this._itemHasSubItems()) {
+    this._getClipboardDataAndSaveIt(clipboardData, this.subItemType, this.saveSubItemsData);
+  }
+}
+
+copyPasteHelper.prototype._getClipboardDataAndSaveIt = function(clipboardData, itemType, saveItemsData) {
+  var itemDataTypeOnClipboard = this._getClipboardDataTypeOf(itemType);
+  var items = clipboardData.getData(itemDataTypeOnClipboard);
+  if (items) {
+    saveItemsData(JSON.parse(items));
+  }
+}
+
+copyPasteHelper.prototype._getClipboardDataTypeOf = function(itemType) {
+  return 'text/object' + this._capitalizeFirstChar(itemType);
+}
+
+copyPasteHelper.prototype._itemHasSubItems = function() {
+  return !!this.subItemType;
+}
+
+/* Possible configs:
+     itemType
+     subItemType
+     itemSelectorOnPad
+     subItemSelectorOnPad
+     getItemsData
+     getSubItemsData
+     getItemIdsFromString
+     getSubItemIdsFromString
+     generateNewItemId
+     generateNewSubItemId
+     setItemIdOnItem
+     setSubItemIdOnSubItem
+     setItemIdOnSubItem
+     getSubItemsOf
+     saveItemsData
+     saveSubItemsData
+*/
+exports.init = function(configs) {
+  var helper = new copyPasteHelper();
+  // add configs as helper properties
+  return _(helper).extend(configs);
+}

--- a/static/js/htmlExtractorFromSelection.js
+++ b/static/js/htmlExtractorFromSelection.js
@@ -1,0 +1,73 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var utils = require('./utils');
+
+exports.getHtmlOfSelectedContent = function() {
+  var range = utils.getPadInner().get(0).getSelection().getRangeAt(0);
+  var $copiedHtml = _createHiddenDiv(range);
+  var onlyTextIsSelected = _selectionHasOnlyText($copiedHtml);
+
+  // when the range selection is fully inside a tag, '$copiedHtml' will have no HTML tag, so we have to
+  // build it. Ex: if we have '<span>ab<b>cdef</b>gh</span>" and user selects 'de', the value of
+  // '$copiedHtml' will be 'de', not '<b>de</b>'
+  if (onlyTextIsSelected) {
+    $copiedHtml = _buildHtmlWithOuterTags($copiedHtml, range);
+  }
+
+  return $copiedHtml;
+}
+
+var _createHiddenDiv = function(range) {
+  var content = range.cloneContents();
+  var div = document.createElement('div');
+  var hiddenDiv = $(div).html(content);
+  return hiddenDiv;
+}
+
+var _selectionHasOnlyText = function($copiedHtml) {
+  var html = $copiedHtml.html();
+  var htmlDecoded = _htmlDecode(html);
+  var text = $copiedHtml.text();
+  return htmlDecoded === text;
+}
+
+// copied from https://css-tricks.com/snippets/javascript/unescape-html-in-js/
+var _htmlDecode = function(input) {
+  var e = document.createElement('div');
+  e.innerHTML = input;
+  return e.childNodes.length === 0 ? '' : e.childNodes[0].nodeValue;
+}
+
+var _buildHtmlWithOuterTags = function($copiedHtml, range) {
+  var htmlTemplate = _getHtmlTemplateWithAllTagsOfSelectedContent(range);
+  var text = $copiedHtml.get(0).textContent;
+  return _splitSelectedTextIntoTwoSpans(text, htmlTemplate);
+};
+
+var _getHtmlTemplateWithAllTagsOfSelectedContent = function(range) {
+  // '.addBack': selected text might be a direct child of the item span
+  var $elementWithItemOnRange = $(range.commonAncestorContainer).parentsUntil('body > div').addBack().first();
+  return $elementWithItemOnRange.get(0).outerHTML;
+}
+
+// FIXME - Allow to copy an item when user copies only one char
+/*
+  This is a hack to preserve the item classes when user pastes an item.
+  When user pastes a span like this: <span class='comment c-124'>thing</span>,
+  chrome removes the classes and keeps only the style of the class.
+  With comments, for example, chrome keeps the background-color. To avoid this
+  we create two spans. The first one, <span class='comment c-124'>thi</span>
+  has the text until the last but one character and second one with the last
+  character <span class='comment c-124'>g</span>.
+  Etherpad does a good job joining the two spans into one after the paste is
+  triggered.
+*/
+var _splitSelectedTextIntoTwoSpans = function(text, itemSpanTemplate) {
+  var $firstSpan = $(itemSpanTemplate);
+  var $secondSpan = $(itemSpanTemplate);
+
+  // '.find('*').last()': need to set text on the deepest tag
+  // '.addBack()': itemSpanTemplate might not have any inner tag
+  $firstSpan.find('*').addBack().last().text(text.slice(0, -1)); // text until before last char
+  $secondSpan.find('*').addBack().last().text(text.slice(-1)); // last char
+  return $('<span>' + $firstSpan.get(0).outerHTML + $secondSpan.get(0).outerHTML + '</span>');
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -151,6 +151,7 @@ ep_comments.prototype.init = function(){
     setItemIdOnItem: function(comment, newCommentId) { comment.commentId = newCommentId },
     setSubItemIdOnSubItem: function(reply, newReplyId) { reply.replyId = newReplyId },
     setItemIdOnSubItem: function(reply, newCommentId) { reply.commentId = newCommentId },
+    getItemIdOfSubItem: function(reply) { return reply.commentId },
     getSubItemsOf: function(comment) { return comment.replies },
     saveItemsData: this.saveCommentWithoutSelection.bind(this),
     saveSubItemsData: this.saveRepliesWithoutSelection.bind(this),
@@ -390,9 +391,10 @@ var hooks = {
 
   // Init pad comments
   postAceInit: function(hook, context){
-    if(!pad.plugins) pad.plugins = {};
     var Comments = new ep_comments(context);
-    pad.plugins.ep_comments_page = Comments;
+    pad.plugins = pad.plugins || {};
+    pad.plugins.ep_comments_page = pad.plugins.ep_comments_page || {};
+    pad.plugins.ep_comments_page.commentHandler = Comments;
   },
 
   aceEditEvent: function(hook, context){
@@ -405,16 +407,16 @@ var hooks = {
     if(context.callstack.docTextChanged) {
       // give a small delay, so all lines will be processed when setYofComments() is called
       setTimeout(function() {
-        pad.plugins.ep_comments_page.setYofComments();
+        pad.plugins.ep_comments_page.commentHandler.setYofComments();
       }, 250);
     }
 
-    var commentWasPasted = pad.plugins && pad.plugins.ep_comments_page && pad.plugins.ep_comments_page.shouldCollectComment;
+    var commentWasPasted = ((((pad || {}).plugins || {}).ep_comments_page || {}).commentHandler || {}).shouldCollectComment;
     var domClean = context.callstack.domClean;
     // we have to wait the DOM update from a fakeComment 'fakecomment-123' to a comment class 'c-123'
     if(commentWasPasted && domClean){
-      pad.plugins.ep_comments_page.collectComments(function(){
-        pad.plugins.ep_comments_page.shouldCollectComment = false;
+      pad.plugins.ep_comments_page.commentHandler.collectComments(function(){
+        pad.plugins.ep_comments_page.commentHandler.shouldCollectComment = false;
       });
     }
   },

--- a/static/js/preTextMarker.js
+++ b/static/js/preTextMarker.js
@@ -96,6 +96,12 @@ preTextMarker.prototype.performNonUnduableEvent = function(eventType, callstack,
   callstack.startNewEvent(eventType);
 }
 
+preTextMarker.prototype.processCollectContentPre = function(context) {
+  var attributeName = this.markClass;
+  var attributeValue = clientVars.userId;
+  context.cc.doAttrib(context.state, attributeName + '::' + attributeValue);
+}
+
 exports.createForTarget = function(targetType, ace) {
   var newMarker = new preTextMarker(targetType, ace);
   pad.preTextMarkers = pad.preTextMarkers || {};
@@ -104,9 +110,14 @@ exports.createForTarget = function(targetType, ace) {
   return newMarker;
 }
 
+// process hooks for all text markers
 exports.processAceEditEvent = function(context) {
-  // process event for all text markers
   _(pad.preTextMarkers).each(function(marker) {
     marker.processAceEditEvent(context);
+  });
+}
+exports.processCollectContentPre = function(context) {
+  _(pad.preTextMarkers).each(function(marker) {
+    marker.processCollectContentPre(context);
   });
 }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,22 +1,57 @@
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 
-exports.collectContentPre = function(hook, context){
-  var commentReplies = (context.cls || '').match(/(?:^| )(cr-[A-Za-z0-9]*)/g) || [];
-  for (var i = 0; i < commentReplies.length; i++) {
-    var replyId = commentReplies[i].trim();
-    context.cc.doAttrib(context.state, 'comment-reply-' + replyId + '::' + replyId);
-  }
+var COMMENT_PREFIX = 'c-';
+var REPLY_PREFIX = 'cr-';
 
-  var comment = /(?:^| )(c-[A-Za-z0-9]*)/.exec(context.cls);
-  if(comment && comment[1]){
-    context.cc.doAttrib(context.state, 'comment::' + comment[1]);
+exports.collectContentPre = function(hook, context){
+  collectAttribFrom(context, REPLY_PREFIX, 'comment-reply-');
+
+  var commentIds = getIdsFrom(context.cls, COMMENT_PREFIX);
+  if (commentIds.length > 0) {
+    // FIXME allow more than one comment on each segment
+    // there can be only one comment on each text segment
+    context.cc.doAttrib(context.state, 'comment::' + commentIds[0]);
   }
 };
 
+exports.getIdsFrom = function(str, classPrefix) {
+  // ex: regex = /(?:^| )(cr-[A-Za-z0-9]*)/g
+  var regex = new RegExp('(?:^| )(' + classPrefix + '[A-Za-z0-9]*)', 'g');
+
+  var ids = (str || '').match(regex) || [];
+  // remove possible whitespaces on the edges of ids
+  ids = _(ids).map(function(id) { return id.trim() });
+  return ids;
+}
+var getIdsFrom = exports.getIdsFrom;
+
+exports.collectAttribFrom = function(context, classPrefix, attribPrefix) {
+  attribPrefix = attribPrefix || '';
+
+  var ids = getIdsFrom(context.cls, classPrefix);
+
+  // there might be more than one attrib id on the same text segment
+  for (var i = 0; i < ids.length; i++) {
+    var id = ids[i];
+    var attribName = attribPrefix + id;
+    var attribValue = id;
+    context.cc.doAttrib(context.state, attribName + '::' + attribValue);
+  }
+}
+var collectAttribFrom = exports.collectAttribFrom;
+
+exports.getCommentIdsFrom = function(str) {
+  return getIdsFrom(str, COMMENT_PREFIX);
+}
+
+exports.getReplyIdsFrom = function(str) {
+  return getIdsFrom(str, REPLY_PREFIX);
+}
+
 exports.generateCommentId = function(){
-  return 'c-' + randomString(16);
+  return COMMENT_PREFIX + randomString(16);
 }
 
 exports.generateReplyId = function(){
-  return 'cr-' + randomString(16);
+  return REPLY_PREFIX + randomString(16);
 }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -3,7 +3,8 @@ var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 var COMMENT_PREFIX = 'c-';
 var REPLY_PREFIX = 'cr-';
 
-var FAKE_ID_PREFIX = 'fake-';
+exports.FAKE_ID_PREFIX = 'fake-';
+var FAKE_ID_PREFIX = exports.FAKE_ID_PREFIX;
 
 exports.collectContentPre = function(hook, context){
   collectAttribFrom(context, REPLY_PREFIX, 'comment-reply-');

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,4 +1,5 @@
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+var preTextMarker = require('./preTextMarker');
 
 var COMMENT_PREFIX = 'c-';
 var REPLY_PREFIX = 'cr-';
@@ -14,6 +15,10 @@ exports.collectContentPre = function(hook, context){
     // FIXME allow more than one comment on each segment
     // there can be only one comment on each text segment
     context.cc.doAttrib(context.state, 'comment::' + commentIds[0]);
+  }
+
+  if (pad && pad.preTextMarkers) {
+    preTextMarker.processCollectContentPre(context);
   }
 };
 

--- a/static/js/shortcuts.js
+++ b/static/js/shortcuts.js
@@ -12,7 +12,7 @@ exports.processAceKeyEvent = function(context) {
   var cmdAndCtrlPressed = eascUtils.isModifierKeyPressed(evt, SHORTCUT_BASE);
   if (cmdAndCtrlPressed && key === SHORTCUT_KEY) {
     evt.preventDefault();
-    pad.plugins.ep_comments_page.displayNewCommentForm(context);
+    pad.plugins.ep_comments_page.commentHandler.displayNewCommentForm(context);
     eventProcessed = true;
   }
 

--- a/static/tests/frontend/specs/commentCopyPaste.js
+++ b/static/tests/frontend/specs/commentCopyPaste.js
@@ -1,10 +1,10 @@
 describe('ep_comments_page - Comment copy and paste', function() {
-  var helperFunctions;
+  var helperFunctions, originalCommentId, originalReplyId;
   var utils = ep_comments_page_test_helper.utils;
   var apiUtils = ep_comments_page_test_helper.apiUtils;
 
-  var FIRST_LINE = 0;
-  var SECOND_LINE = 1;
+  var LINE_WITH_ORIGINAL_COMMENT = 0;
+  var LINE_WITH_PASTED_COMMENT = 1;
 
   var COMMENT_TEXT = 'My comment';
   var REPLY_TEXT = 'A reply';
@@ -12,35 +12,38 @@ describe('ep_comments_page - Comment copy and paste', function() {
   before(function(done) {
     helperFunctions = ep_comments_page_test_helper.copyAndPaste;
     utils.createPad(this, function() {
-      utils.addCommentAndReplyToLine(FIRST_LINE, COMMENT_TEXT, REPLY_TEXT, done);
+      utils.addCommentAndReplyToLine(LINE_WITH_ORIGINAL_COMMENT, COMMENT_TEXT, REPLY_TEXT, function() {
+        originalCommentId = utils.getCommentIdOfLine(LINE_WITH_ORIGINAL_COMMENT);
+        originalReplyId = utils.getReplyIdOfLine(LINE_WITH_ORIGINAL_COMMENT);
+        done();
+      });
     });
     this.timeout(60000);
   });
 
   context('when user copies and pastes a text with comment and reply', function() {
-    var originalCommentId, originalReplyId;
-
     before(function(done) {
       var $firstLine = helper.padInner$('div').eq(0);
       helper.selectLines($firstLine, $firstLine, 1, 8); //'omethin'
 
-      originalCommentId = utils.getCommentIdOfLine(FIRST_LINE);
-      originalReplyId = utils.getReplyIdOfLine(FIRST_LINE);
-
       utils.copySelection();
-      utils.pasteOnLine(SECOND_LINE, function() {
-        utils.waitForCommentToBeCreatedOnLine(SECOND_LINE, done);
+      utils.pasteOnLine(LINE_WITH_PASTED_COMMENT, function() {
+        utils.waitForCommentToBeCreatedOnLine(LINE_WITH_PASTED_COMMENT, done);
       });
     });
 
+    after(function(done) {
+      helperFunctions.performActionAndWaitForDataToBeSent(utils.undo, done);
+    });
+
     it('generates a different comment id for the comment pasted', function(done) {
-      var commentIdLinePasted = utils.getCommentIdOfLine(SECOND_LINE);
+      var commentIdLinePasted = utils.getCommentIdOfLine(LINE_WITH_PASTED_COMMENT);
       expect(commentIdLinePasted).to.not.be(originalCommentId);
       done();
     });
 
     it('generates a different reply id for the reply pasted', function(done) {
-      var replyIdLinePasted = utils.getReplyIdOfLine(SECOND_LINE);
+      var replyIdLinePasted = utils.getReplyIdOfLine(LINE_WITH_PASTED_COMMENT);
       expect(replyIdLinePasted).to.not.be(originalReplyId);
       done();
     });
@@ -49,20 +52,20 @@ describe('ep_comments_page - Comment copy and paste', function() {
       var outer$ = helper.padOuter$;
 
       helper.waitFor(function() {
-        var $commentIcon = outer$('.comment-icon.withReply');
+        var $commentIcon = outer$('.comment-icon.withReply:visible');
         // 2 = the original comment and the pasted one
         return $commentIcon.length === 2;
       }).done(done);
     });
 
     it('creates the comment text field with the same text of the one copied', function(done) {
-      var commentPastedText = helperFunctions.getTextOfCommentFromLine(SECOND_LINE);
+      var commentPastedText = helperFunctions.getTextOfCommentFromLine(LINE_WITH_PASTED_COMMENT);
       expect(commentPastedText).to.be(COMMENT_TEXT);
       done();
     });
 
     it('creates the comment reply text field with the same text of the one copied', function(done) {
-      var commentReplyText = helperFunctions.getTextOfCommentReplyFromLine(SECOND_LINE);
+      var commentReplyText = helperFunctions.getTextOfCommentReplyFromLine(LINE_WITH_PASTED_COMMENT);
       expect(commentReplyText).to.be(REPLY_TEXT);
       done();
     });
@@ -72,8 +75,8 @@ describe('ep_comments_page - Comment copy and paste', function() {
         apiUtils.simulateCallToDeleteComment(originalCommentId);
       });
 
-      after(function() {
-        utils.undo();
+      after(function(done) {
+        helperFunctions.performActionAndWaitForDataToBeSent(utils.undo, done);
       });
 
       it('does not remove the comment pasted', function(done) {
@@ -82,6 +85,53 @@ describe('ep_comments_page - Comment copy and paste', function() {
         expect(commentsLength).to.be(1);
         done();
       });
+    });
+  });
+
+  context('when user copies and pastes a text with only comment', function() {
+    before(function(done) {
+      apiUtils.resetData();
+      apiUtils.simulateCallToDeleteReply(originalReplyId, originalCommentId);
+
+      // remove reply to run this context
+      apiUtils.waitForDataToBeSent(function() {
+        var $firstLine = helper.padInner$('div').eq(0);
+        helper.selectLines($firstLine, $firstLine, 1, 8); //'omethin'
+
+        utils.copySelection();
+        utils.pasteOnLine(LINE_WITH_PASTED_COMMENT, function() {
+          utils.waitForCommentToBeCreatedOnLine(LINE_WITH_PASTED_COMMENT, done);
+        });
+      });
+    });
+
+    after(function(done) {
+      helperFunctions.performActionAndWaitForDataToBeSent(function() {
+        utils.undo(); // paste
+        utils.undo(); // reply deletion
+      }, done);
+    });
+
+    it('generates a different comment id for the comment pasted', function(done) {
+      var commentIdLinePasted = utils.getCommentIdOfLine(LINE_WITH_PASTED_COMMENT);
+      expect(commentIdLinePasted).to.not.be(originalCommentId);
+      done();
+    });
+
+    it('creates a new icon for the comment pasted', function(done) {
+      var outer$ = helper.padOuter$;
+
+      helper.waitFor(function() {
+        var $commentIcon = outer$('.comment-icon:visible');
+        // 2 = the original comment and the pasted one
+        return $commentIcon.length === 2;
+      }).done(done);
+    });
+
+    it('creates the comment text field with the same text of the one copied', function(done) {
+      var commentPastedText = helperFunctions.getTextOfCommentFromLine(LINE_WITH_PASTED_COMMENT);
+      expect(commentPastedText).to.be(COMMENT_TEXT);
+      done();
     });
   });
 
@@ -103,37 +153,37 @@ describe('ep_comments_page - Comment copy and paste', function() {
       helper.selectLines($firstLine, $firstLine, 3, 6); //'eth'
 
       utils.copySelection();
-      utils.pasteOnLine(SECOND_LINE, function() {
-        utils.waitForCommentToBeCreatedOnLine(SECOND_LINE, done);
+      utils.pasteOnLine(LINE_WITH_PASTED_COMMENT, function() {
+        utils.waitForCommentToBeCreatedOnLine(LINE_WITH_PASTED_COMMENT, done);
       });
     });
 
     it('pastes a new comment', function(done) {
-      var commentIdLinePasted = utils.getCommentIdOfLine(SECOND_LINE);
+      var commentIdLinePasted = utils.getCommentIdOfLine(LINE_WITH_PASTED_COMMENT);
       expect(commentIdLinePasted).to.not.be(undefined);
       done();
     });
 
     it('pastes a new reply', function(done) {
-      var replyIdLinePasted = utils.getReplyIdOfLine(SECOND_LINE);
+      var replyIdLinePasted = utils.getReplyIdOfLine(LINE_WITH_PASTED_COMMENT);
       expect(replyIdLinePasted).to.not.be(undefined);
       done();
     });
 
     it('pastes content with the outer formatting', function(done) {
-      var $pastedContent = utils.getLine(SECOND_LINE);
+      var $pastedContent = utils.getLine(LINE_WITH_PASTED_COMMENT);
       expect($pastedContent.find('b').length).to.not.be(0);
       done();
     });
 
     it('pastes content with the formatting in the middle', function(done) {
-      var $pastedContent = utils.getLine(SECOND_LINE);
+      var $pastedContent = utils.getLine(LINE_WITH_PASTED_COMMENT);
       expect($pastedContent.find('i').length).to.not.be(0);
       done();
     });
 
     it('pastes content with the inner formatting', function(done) {
-      var $pastedContent = utils.getLine(SECOND_LINE);
+      var $pastedContent = utils.getLine(LINE_WITH_PASTED_COMMENT);
       expect($pastedContent.find('u').length).to.not.be(0);
       done();
     });
@@ -153,4 +203,12 @@ ep_comments_page_test_helper.copyAndPaste = {
     var replyIds = Object.keys(commentData.replies);
     return commentData.replies[replyIds[0]].text;
   },
+
+  performActionAndWaitForDataToBeSent: function(action, done) {
+    var apiUtils = ep_comments_page_test_helper.apiUtils;
+    apiUtils.resetData();
+    action();
+    // wait until all data is restored
+    apiUtils.waitForDataToBeSent(done);
+  }
 };

--- a/static/tests/frontend/specs/preCommentMark.js
+++ b/static/tests/frontend/specs/preCommentMark.js
@@ -98,6 +98,37 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
   });
 
+  context('when user edits the originally selected text', function() {
+    var newText = '(edited)';
+
+    before(function(done) {
+      var inner$ = helper.padInner$;
+
+      var $firstLine = inner$('div').first();
+      $firstLine.sendkeys('{selectall}{rightarrow}' + newText + '{enter}{enter}');
+
+      helper.waitFor(function() {
+        var $secondLine = inner$('div').first().next();
+        return $secondLine.text() === '';
+      }).done(done);
+    });
+
+    after(function() {
+      utils.undo();
+    });
+
+    it('keeps marked text', function(done) {
+      var inner$ = helper.padInner$;
+
+      // verify if text is still marked with pre-comment class
+      var $preCommentTextMarked = inner$('.pre-selected-comment');
+      expect($preCommentTextMarked.length).to.be(1);
+      expect($preCommentTextMarked.text()).to.be(firstLineText + newText);
+
+      done();
+    });
+  });
+
   context('when user selects another text range and opens New Comment form for it', function() {
     before(function(done) {
       selectLineAndOpenCommentForm(1, done, true);


### PR DESCRIPTION
For now it is used also by [ep_touch](https://github.com/storytouch/ep_script_touches).

Also:
* [fix] Paste different comments every time user triggers paste: if user triggers paste twice, each time a different comment must be generated -- if clipboard has a text with comment, of course. Use 'fake-' prefix to mark the temporary comment and reply ids.

Fix https://trello.com/c/lYvVVozd/1116;
Implements part of https://trello.com/c/CPZEA0xK/1103/;