### PR TITLE
[fix] Allow user to go back to editing pad after a dialog is closed

### DIFF
--- a/static/js/dialog.js
+++ b/static/js/dialog.js
@@ -226,9 +226,6 @@ dialog.prototype.isOpen = function() {
 dialog.prototype.close = function() {
   this.$content.dialog('close');
 
-  // force focus to be lost, so virtual keyboard is hidden on mobile devices
-  utils.getPadOuter().find(':focus').blur();
-
   // de-select text when dialog is closed
   if (this.shouldMarkText) {
     this.textMarker.unmarkSelectedText();


### PR DESCRIPTION
When a dialog is being closed, we're bluring the focus on padOuter,
which does not allow user to go back to typing after dialog finishes
closing. The code that is causing the issue is mobile-specific, so we're
removing it -- a broader strategy needs to be planned anyway when we
decide to support mobile devices.