### PR TITLE
[design] make close button bigger

### DIFF
--- a/templates/comments.html
+++ b/templates/comments.html
@@ -3,8 +3,8 @@
 
 <script id="closeButton" type="text/html">
   <span>
-    <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 9.9 9.9">
-      <polygon points="6.9 2.3 5 4.2 3 2.3 2.3 3 4.2 5 2.3 6.9 3 7.6 5 5.7 6.9 7.6 7.6 6.9 5.7 5 7.6 3 "/>
+    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="9px" height="9px" viewBox="-300.4 391.6 10.7 10.7" enable-background="new 0 0 10 10" xml:space="preserve">
+      <polygon points="-290.4,391.6 -294.9,396.2 -299.6,391.6 -300.4,392.4 -295.8,397.1 -300.4,401.6 -299.6,402.4 -294.9,397.8 -290.4,402.4 -289.6,401.6 -294.2,397.1 -289.6,392.4 "/>
     </svg>
   </span>
 </script>

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -3,8 +3,8 @@
 
 <script id="closeButton" type="text/html">
   <span>
-    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="9px" height="9px" viewBox="-300.4 391.6 10.7 10.7" enable-background="new 0 0 10 10" xml:space="preserve">
-      <polygon points="-290.4,391.6 -294.9,396.2 -299.6,391.6 -300.4,392.4 -295.8,397.1 -300.4,401.6 -299.6,402.4 -294.9,397.8 -290.4,402.4 -289.6,401.6 -294.2,397.1 -289.6,392.4 "/>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-300.4 391.6 10.7 10.7" width="9px" height="9px">
+      <polygon points="-290.4 391.6 -294.9 396.2 -299.6 391.6 -300.4 392.4 -295.8 397.1 -300.4 401.6 -299.6 402.4 -294.9 397.8 -290.4 402.4 -289.6 401.6 -294.2 397.1 -289.6 392.4 "/>
     </svg>
   </span>
 </script>


### PR DESCRIPTION
@lpagliari o ícone de fechar as janelas flutuantes estava muito pequenininho.
Mexer no tamanho dele pelo HTML, pois tem muuuito CSS de herança envolvido e de uma maneira que não atrapalhasse o `fill` usado pelos estados.
Será que dessa forma tá tudo bem?