### PR TITLE
[fix] Do not scroll editor when dialog is opened/closed

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -11,6 +11,7 @@
         "aceAttribsToClasses": "ep_comments_page/static/js/index",
         "aceEditorCSS": "ep_comments_page/static/js/index",
         "aceEditEvent": "ep_comments_page/static/js/index",
+        "aceRegisterNonScrollableEditEvents": "ep_comments_page/static/js/index",
         "aceInitialized": "ep_comments_page/static/js/index"
       },
       "hooks": {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -551,3 +551,7 @@ exports.aceInitialized = function(hook, context){
   editorInfo.ace_getRepFromSelector = _(getRepFromSelector).bind(context);
   editorInfo.ace_getRepFromDOMElement = _(getRepFromDOMElement).bind(context);
 }
+
+exports.aceRegisterNonScrollableEditEvents = function(){
+  return [preTextMarker.MARK_TEXT_EVENT, preTextMarker.UNMARK_TEXT_EVENT];
+}


### PR DESCRIPTION
Implement part of https://trello.com/c/YBrcLRNJ/1141: "2. não permitir scroll automatico quando scrollamos logo após o highlight".