### PR TITLE
[fix] Avoid marking ALL TEXT with preText attribs (woot?!)

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -7,7 +7,7 @@
       "client_hooks": {
         "postAceInit": "ep_comments_page/static/js/index",
         "aceKeyEvent": "ep_comments_page/static/js/index",
-        "collectContentPre": "ep_comments_page/static/js/shared:collectContentPreOnFrontEnd",
+        "collectContentPre": "ep_comments_page/static/js/index",
         "aceAttribsToClasses": "ep_comments_page/static/js/index",
         "aceEditorCSS": "ep_comments_page/static/js/index",
         "aceEditEvent": "ep_comments_page/static/js/index",

--- a/static/js/dialog.js
+++ b/static/js/dialog.js
@@ -116,7 +116,7 @@ dialog.prototype.open = function(aceContext, callbackOnSubmit) {
     var $form = $(this);
 
     self.ace.callWithAce(function(ace) {
-      var preMarkedTextSelector = '.' + self.textMarker.markClass;
+      var preMarkedTextSelector = self.textMarker.getMarkerSelector();
       var preMarkedTextRepArr = ace.ace_getRepFromSelector(preMarkedTextSelector);
       self.onSubmit($form, preMarkedTextRepArr, callbackOnSubmit);
     });
@@ -213,7 +213,7 @@ dialog.prototype._cleanupReferenceElementOnPadOuter = function() {
 }
 
 dialog.prototype._getSelectedText = function() {
-  var selector = '.' + this.textMarker.markClass;
+  var selector = this.textMarker.getMarkerSelector();
   var $selectedText = utils.getPadInner().find(selector);
 
   // when multiple lines are selected, use first one as reference to create the shadow

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -403,10 +403,7 @@ var hooks = {
     else if(context.key.startsWith('comment-reply-')) {
       return ['comment-reply', context.value];
     }
-    // only read marks made by current user
-    else if(context.key.startsWith(preTextMarker.BASE_CLASS) && context.value === clientVars.userId) {
-      return [context.key];
-    }
+    return preTextMarker.processAceAttribsToClasses(context);
   },
 
   aceEditorCSS: function(){
@@ -529,4 +526,9 @@ exports.aceInitialized = function(hook, context){
 
 exports.aceRegisterNonScrollableEditEvents = function(){
   return [preTextMarker.MARK_TEXT_EVENT, preTextMarker.UNMARK_TEXT_EVENT];
+}
+
+exports.collectContentPre = function(hook, context){
+  shared.collectContentPre(hook, context);
+  preTextMarker.processCollectContentPre(context);
 }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,17 +1,11 @@
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
-var preTextMarker = require('./preTextMarker');
 
 var COMMENT_PREFIX = 'c-';
 var REPLY_PREFIX = 'cr-';
 
 exports.FAKE_ID_PREFIX = 'fake-';
 var FAKE_ID_PREFIX = exports.FAKE_ID_PREFIX;
-
-exports.collectContentPreOnFrontEnd = function(hook, context){
-  collectContentPre(hook, context);
-  preTextMarker.processCollectContentPre(context);
-}
 
 exports.collectContentPre = function(hook, context){
   collectAttribFrom(context, REPLY_PREFIX, 'comment-reply-');
@@ -23,7 +17,6 @@ exports.collectContentPre = function(hook, context){
     context.cc.doAttrib(context.state, 'comment::' + commentIds[0]);
   }
 };
-var collectContentPre = exports.collectContentPre;
 
 exports.getIdsFrom = function(str, classPrefix) {
   // ex: regex = /(?:^| |fake-)(cr-[A-Za-z0-9]*)/g

--- a/static/tests/frontend/specs/preCommentMark.js
+++ b/static/tests/frontend/specs/preCommentMark.js
@@ -1,11 +1,12 @@
 describe('ep_comments_page - Pre-comment text mark', function() {
   var utils = ep_comments_page_test_helper.utils;
-  var firstLineText, secondLineText;
+  var firstLineText, secondLineText, markClass;
 
   before(function(done) {
     utils.createPad(this, function() {
       firstLineText = utils.getLine(0).text();
       secondLineText = utils.getLine(1).text();
+      markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
       selectLineAndOpenCommentForm(0, done);
     });
   });
@@ -14,7 +15,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     var inner$ = helper.padInner$;
 
     // verify if text was marked with pre-comment class
-    var $preCommentTextMarked = inner$('.pre-selected-comment');
+    var $preCommentTextMarked = inner$('.' + markClass);
     expect($preCommentTextMarked.length).to.be(1);
     expect($preCommentTextMarked.text()).to.be(firstLineText);
 
@@ -36,7 +37,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
 
       // it takes some time for marks to be removed, so wait for it
       helper.waitFor(function() {
-        var $preCommentTextMarked = inner$('.pre-selected-comment');
+        var $preCommentTextMarked = inner$('.' + markClass);
         return $preCommentTextMarked.length === 0;
       }).done(done);
     });
@@ -68,7 +69,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
       var inner$ = helper.padInner$;
 
       // verify if there is no text marked with pre-comment class
-      var $preCommentTextMarked = inner$('.pre-selected-comment');
+      var $preCommentTextMarked = inner$('.' + markClass);
       expect($preCommentTextMarked.length).to.be(0);
 
       done();
@@ -90,7 +91,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
       var inner$ = helper.padInner$;
 
       // verify if text was marked with pre-comment class
-      var $preCommentTextMarked = inner$('.pre-selected-comment');
+      var $preCommentTextMarked = inner$('.' + markClass);
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(firstLineText);
 
@@ -121,7 +122,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
       var inner$ = helper.padInner$;
 
       // verify if text is still marked with pre-comment class
-      var $preCommentTextMarked = inner$('.pre-selected-comment');
+      var $preCommentTextMarked = inner$('.' + markClass);
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(firstLineText + newText);
 
@@ -141,7 +142,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
       var inner$ = helper.padInner$;
 
       // verify if text was marked with pre-comment class
-      var $preCommentTextMarked = inner$('.pre-selected-comment');
+      var $preCommentTextMarked = inner$('.' + markClass);
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(secondLineText);
 
@@ -166,7 +167,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
 
       // it takes some time for marks to be removed, so wait for it
       helper.waitFor(function() {
-        var $preCommentTextMarked = inner$('.pre-selected-comment');
+        var $preCommentTextMarked = inner$('.' + markClass);
         return $preCommentTextMarked.length === 0;
       }).done(done);
     });
@@ -197,7 +198,7 @@ describe('ep_comments_page - Pre-comment text mark', function() {
       var inner$ = helper.padInner$;
 
       // verify if text was marked with pre-comment class
-      var $preCommentTextMarked = inner$('.pre-selected-comment');
+      var $preCommentTextMarked = inner$('.' + markClass);
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(firstLineText);
 


### PR DESCRIPTION
There was a bug on `collectContentPre`: it was not checking for pre-existing attribs, it was simply adding the preText attrib EVERY TIME!

As a consequence, after a very long paste, the entire pad would be marked with the attrib, and when pad was reloaded it took forever to clean up all those lines, which was causing the browser to freeze and the "saving" message to be displayed several times to the user.

Fix https://trello.com/c/KskaudQ5/1190.
Code that created the bug: https://trello.com/c/VQe860CS/763.