### PR TITLE
[fix] Do not scroll editor when opening/closing dialogs

### DIFF
--- a/static/js/preTextMarker.js
+++ b/static/js/preTextMarker.js
@@ -52,11 +52,11 @@ preTextMarker.prototype.processAceEditEvent = function(context) {
   var eventType  = callstack.editEvent.eventType;
 
   if(eventType === this.unmarkTextEvent) {
-    this.handleUnmarkText(editorInfo, rep, callstack);
     this.avoidEditorToBeScrolled(callstack, UNMARK_TEXT_EVENT);
+    this.handleUnmarkText(editorInfo, rep, callstack);
   } else if(eventType === this.markTextEvent) {
-    this.handleMarkText(editorInfo, rep, callstack);
     this.avoidEditorToBeScrolled(callstack, MARK_TEXT_EVENT);
+    this.handleMarkText(editorInfo, rep, callstack);
   }
 }
 

--- a/static/tests/frontend/specs/shortcuts.js
+++ b/static/tests/frontend/specs/shortcuts.js
@@ -38,10 +38,10 @@ describe('ep_comments_page - Shortcuts', function() {
     });
 
     it('unmarks text', function(done) {
-      var inner$ = helper.padInner$;
+      var markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
 
       // verify if there is no text marked with pre-comment class
-      var $preCommentTextMarked = inner$('.pre-selected-comment');
+      var $preCommentTextMarked = helper.padInner$('.' + markClass);
       expect($preCommentTextMarked.length).to.be(0);
 
       done();


### PR DESCRIPTION
Operations to mark/unmark text might need to call `inCallStack`, which would affect the scroll. Make sure the callstack event type is non-scrollable before performing the action itself.

Fix https://trello.com/c/cOo0fj64/1163.