### PR TITLE
[refactor] Extract component to trigger event every time a line changes

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -11,6 +11,7 @@ var preTextMarker = require('./preTextMarker');
 var commentDataManager = require('./commentDataManager');
 var commentL10n = require('./commentL10n');
 var copyPasteEvents = require('./copyPasteEvents');
+var lineChangeEventTriggerer = require('./lineChangeEventTriggerer');
 var api = require('./api');
 var utils = require('./utils');
 var commentSaveOrDelete = require('./commentSaveOrDelete');
@@ -47,6 +48,7 @@ function ep_comments(context){
 
   api.init();
   copyPasteEvents.init();
+  this.lineChangeEventTriggerer = lineChangeEventTriggerer.init(this.ace);
   this.commentDataManager = commentDataManager.init(this.socket);
   this.commentIcons = commentIcons.init(this.ace);
   this.init();
@@ -180,7 +182,6 @@ ep_comments.prototype.tryToCollectCommentsAndRetryIfNeeded = function(timeToWait
 ep_comments.prototype.collectComments = function(callback) {
   this.commentDataManager.updateListOfCommentsStillOnText();
   this.commentIcons.addIcons(this.commentDataManager.getComments());
-  this.commentIcons.updateAllIconsPosition();
 
   if(callback) callback();
 };

--- a/static/js/lineChangeEventTriggerer.js
+++ b/static/js/lineChangeEventTriggerer.js
@@ -1,0 +1,71 @@
+var _ = require('ep_etherpad-lite/static/js/underscore');
+
+var detailedLinesChangedListener = require('ep_script_scene_marks/static/js/detailedLinesChangedListener');
+var eascUtils = require('ep_script_toggle_view/static/js/utils');
+
+var utils     = require('./utils');
+var scheduler = require('./scheduler');
+
+var FIRST_LINE_OF_PAD = 0;
+
+var lineChangeEventTriggerer = function(ace) {
+  this.minLineChanged = undefined;
+  this.rep = this._getRep(ace);
+  this._listenToDifferentScenariosWhereLinePositionMightChangeOnScreen();
+}
+
+lineChangeEventTriggerer.prototype._getRep = function(ace) {
+  var rep;
+  ace.callWithAce(function(ace) {
+    rep = ace.ace_getRep();
+  });
+  return rep;
+}
+
+lineChangeEventTriggerer.prototype._listenToDifferentScenariosWhereLinePositionMightChangeOnScreen = function() {
+  var self = this;
+
+  // to avoid lagging while user is typing, we set a scheduler to postpone
+  // calling callback until edition had stopped
+  this.padChangedListener = scheduler.setCallbackWhenUserStopsChangingPad(
+    self._triggerLineChangedForMinimunLine.bind(self)
+  );
+
+  detailedLinesChangedListener.onLinesAddedOrRemoved(function(linesChanged) {
+    self._updateMinLineChanged(linesChanged.linesNumberOfChangedNodes);
+    self.padChangedListener.padChanged();
+  }, true, this.rep);
+
+  // When screen size changes (user changes device orientation, for example),
+  // we need to make sure all sidebar comments are on the correct place
+  utils.waitForResizeToFinishThenCall(200, function() {
+    self._triggerLineChangedForEntirePad();
+  });
+
+  utils.getPadInner().on(eascUtils.EASC_CHANGED_EVENT, function(e) {
+    self._triggerLineChangedForEntirePad();
+  });
+}
+
+lineChangeEventTriggerer.prototype._updateMinLineChanged = function(linesChangedOnThisBatch) {
+  var topLineChangedOnThisBatch = _.min(linesChangedOnThisBatch);
+  this.minLineChanged = _.min([topLineChangedOnThisBatch, this.minLineChanged]);
+}
+
+lineChangeEventTriggerer.prototype._triggerLineChangedForMinimunLine = function() {
+  this._tellOtherPluginsThatLineChanged(this.minLineChanged || FIRST_LINE_OF_PAD);
+  this.minLineChanged = undefined; // reset value
+}
+
+lineChangeEventTriggerer.prototype._triggerLineChangedForEntirePad = function() {
+  this._tellOtherPluginsThatLineChanged(FIRST_LINE_OF_PAD);
+}
+
+lineChangeEventTriggerer.prototype._tellOtherPluginsThatLineChanged = function(lineNumber) {
+  var $innerDoc = utils.getPadInner().find('#innerdocbody');
+  $innerDoc.trigger(utils.LINE_CHANGED_EVENT, { lineNumber: lineNumber });
+}
+
+exports.init = function(ace) {
+  return new lineChangeEventTriggerer(ace);
+}

--- a/static/js/textMarkIconsPosition.js
+++ b/static/js/textMarkIconsPosition.js
@@ -4,7 +4,7 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var utils = require('./utils');
 var shared = require('./shared');
 
-var FIRST_LINE_OF_SCRIPT = 0;
+var FIRST_LINE_OF_PAD = 0;
 /*
 Values of config:
   - hideIcons: function that hides the target icons
@@ -22,11 +22,15 @@ var textMarkIconsPosition = function(config) {
 // Set all text mark icons to be aligned with text where's applied
 // or when it is applied on a hidden line, it looks for a eligible
 // line to show it aside
-textMarkIconsPosition.prototype.updateIconsPosition = function(updateAllIconsPosition, lineOfChange) {
-  this.hideIcons(updateAllIconsPosition);
+textMarkIconsPosition.prototype.updateAllIconsPosition = function() {
+  this.updateIconsPosition(FIRST_LINE_OF_PAD);
+}
+textMarkIconsPosition.prototype.updateIconsPosition = function(lineOfChange) {
+  var updateAllIcons = lineOfChange === FIRST_LINE_OF_PAD;
+  this.hideIcons(updateAllIcons);
 
   var self = this;
-  var inlineTextMarks = this._getTextMarkIdAndItsPosition(updateAllIconsPosition, lineOfChange);
+  var inlineTextMarks = this._getTextMarkIdAndItsPosition(lineOfChange);
   $.each(inlineTextMarks, function() {
     if(this.textMarkId && this.textMarkIconPosition) {
       self.adjustTopOf(this.textMarkId, this.textMarkIconPosition);
@@ -34,19 +38,18 @@ textMarkIconsPosition.prototype.updateIconsPosition = function(updateAllIconsPos
   });
 }
 
-textMarkIconsPosition.prototype._getTextMarkIdAndItsPosition = function(updateAllIconsPosition, lineOfChange) {
-  var textMarksId = this._getUniqueTextMarksId(updateAllIconsPosition, lineOfChange);
+textMarkIconsPosition.prototype._getTextMarkIdAndItsPosition = function(lineOfChange) {
+  var textMarksId = this._getUniqueTextMarksId(lineOfChange);
   var textMarkIdAndItsPosition = _.map(textMarksId, function(textMarkId) {
     return { textMarkId: textMarkId, textMarkIconPosition: this._getTextMarkIconPosition(textMarkId) };
   }, this);
   return textMarkIdAndItsPosition;
  }
 
- textMarkIconsPosition.prototype._getUniqueTextMarksId = function(updateAllIconsPosition, lineOfChange) {
-  // targetLine is the line that's used as first one of the interval that we need
-  // to recalculate textMark icons' position
-  var targetLine = updateAllIconsPosition ? FIRST_LINE_OF_SCRIPT : lineOfChange;
-  var $lines = utils.getPadInner().find('div').eq(targetLine).nextAll().addBack();
+ // lineOfChange is the line that's used as first one of the interval that we need
+ // to recalculate textMark icons' position
+ textMarkIconsPosition.prototype._getUniqueTextMarksId = function(lineOfChange) {
+  var $lines = utils.getPadInner().find('div').eq(lineOfChange).nextAll().addBack();
   var inlineTextMarks = $lines.find(this.textMarkClass);
   return _(inlineTextMarks)
     .chain()

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,6 +1,7 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var smUtils = require('ep_script_scene_marks/static/js/utils');
 
+exports.LINE_CHANGED_EVENT = 'LINE_CHANGED_EVENT';
 exports.OPEN_NEW_COMMENT_MODAL_EVENT = 'OPEN_NEW_COMMENT_MODAL_EVENT';
 exports.COMMENT_CLASS = '.comment';
 

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -15,11 +15,20 @@ ep_comments_page_test_helper.utils = {
       self._enlargeScreen();
       self._chooseToShowComments();
 
+      // use a shorter timeout, so tests don't take too long to build icons
+      self.speedUpIconCreation();
+
       // wait for all helper libs to be loaded
       helper.waitFor(function() {
         return helper.padOuter$.window.scrollIntoView;
       }).done(done);
     }, this.padId);
+  },
+
+  speedUpIconCreation: function() {
+    var thisPlugin = helper.padChrome$.window.pad.plugins.ep_comments_page;
+    thisPlugin.commentHandler.lineChangeEventTriggerer.padChangedListener.timeout = 0;
+    thisPlugin.commentHandler.commentIcons.timeToUpdateIconPosition = 0;
   },
 
   createPad: function(test, done, scriptContent, lastLineText) {

--- a/static/tests/frontend/specs/multipleCommentsOnSameRange.js
+++ b/static/tests/frontend/specs/multipleCommentsOnSameRange.js
@@ -27,7 +27,7 @@ describe('ep_comments_page - allow add comments on a same range of text', functi
     },
 
     createTwoCommentsThatOverlaps: function (cb) {
-      utils.addCommentToLine(FIRST_COMMENT_LINE, FIRST_COMMENT_TEXT, function(){
+      utils.addCommentToLine(FIRST_COMMENT_LINE, FIRST_COMMENT_TEXT, function() {
         // give an extra time to create the second comment
         setTimeout(function() {
           utils.addCommentToLines([FIRST_COMMENT_LINE, SECOND_COMMENT_LINE], SECOND_COMMENT_TEXT, cb);
@@ -45,10 +45,10 @@ describe('ep_comments_page - allow add comments on a same range of text', functi
     });
   }
 
-  context('when user adds more than one comment on the same range', function(){
+  context('when user adds more than one comment on the same range', function() {
     before(function (done) {
       // we create a comment so we create a second one that wraps the first one
-      helpersOfCommentsOnSameRange.createTwoCommentsThatOverlaps(function(){
+      helpersOfCommentsOnSameRange.createTwoCommentsThatOverlaps(function() {
         helpersOfCommentsOnSameRange.getCommentIds();
         done();
       });
@@ -65,17 +65,18 @@ describe('ep_comments_page - allow add comments on a same range of text', functi
 
     it('sends the data of the comment created via API', function (done) {
       var comments = apiUtils.getLastDataSent();
+      var commentsText = comments.map(function(comment) { return comment.text });
       expect(comments.length).to.be(2);
-      expect(comments[0].text).to.be(SECOND_COMMENT_TEXT);
-      expect(comments[1].text).to.be(FIRST_COMMENT_TEXT);
+      expect(commentsText).to.contain(FIRST_COMMENT_TEXT);
+      expect(commentsText).to.contain(SECOND_COMMENT_TEXT);
       done();
     });
 
-    context('when user edits a text with a comment applied', function(){
+    context('when user edits a text with a comment applied', function() {
       before(function (done) {
         var $firstLine = utils.getLine(FIRST_COMMENT_LINE);
         $firstLine.sendkeys('{selectall}{rightarrow}{backspace}')
-        helper.waitFor(function(){
+        helper.waitFor(function() {
           var $firstLine = utils.getLine(FIRST_COMMENT_LINE);
           var firstLineText = $firstLine.text();
           return firstLineText === 'somethin'; // remove the last char of the 1st line

--- a/static/tests/frontend/specs/preCommentMark.js
+++ b/static/tests/frontend/specs/preCommentMark.js
@@ -1,21 +1,18 @@
 describe('ep_comments_page - Pre-comment text mark', function() {
   var utils = ep_comments_page_test_helper.utils;
-  var firstLineText, secondLineText, markClass;
+  var firstLineText, secondLineText;
 
   before(function(done) {
     utils.createPad(this, function() {
       firstLineText = utils.getLine(0).text();
       secondLineText = utils.getLine(1).text();
-      markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
       selectLineAndOpenCommentForm(0, done);
     });
   });
 
   it('marks selected text when New Comment form is opened', function(done) {
-    var inner$ = helper.padInner$;
-
     // verify if text was marked with pre-comment class
-    var $preCommentTextMarked = inner$('.' + markClass);
+    var $preCommentTextMarked = getPreCommentTextMarked();
     expect($preCommentTextMarked.length).to.be(1);
     expect($preCommentTextMarked.text()).to.be(firstLineText);
 
@@ -33,11 +30,9 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
 
     it('unmarks text', function(done) {
-      var inner$ = helper.padInner$;
-
       // it takes some time for marks to be removed, so wait for it
       helper.waitFor(function() {
-        var $preCommentTextMarked = inner$('.' + markClass);
+        var $preCommentTextMarked = getPreCommentTextMarked();
         return $preCommentTextMarked.length === 0;
       }).done(done);
     });
@@ -66,10 +61,8 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
 
     it('unmarks text', function(done) {
-      var inner$ = helper.padInner$;
-
       // verify if there is no text marked with pre-comment class
-      var $preCommentTextMarked = inner$('.' + markClass);
+      var $preCommentTextMarked = getPreCommentTextMarked();
       expect($preCommentTextMarked.length).to.be(0);
 
       done();
@@ -88,10 +81,8 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
 
     it('keeps marked text', function(done) {
-      var inner$ = helper.padInner$;
-
       // verify if text was marked with pre-comment class
-      var $preCommentTextMarked = inner$('.' + markClass);
+      var $preCommentTextMarked = getPreCommentTextMarked();
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(firstLineText);
 
@@ -119,10 +110,8 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
 
     it('keeps marked text', function(done) {
-      var inner$ = helper.padInner$;
-
       // verify if text is still marked with pre-comment class
-      var $preCommentTextMarked = inner$('.' + markClass);
+      var $preCommentTextMarked = getPreCommentTextMarked();
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(firstLineText + newText);
 
@@ -139,10 +128,8 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
 
     it('changes the marked text', function(done) {
-      var inner$ = helper.padInner$;
-
       // verify if text was marked with pre-comment class
-      var $preCommentTextMarked = inner$('.' + markClass);
+      var $preCommentTextMarked = getPreCommentTextMarked();
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(secondLineText);
 
@@ -163,11 +150,9 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
 
     it('does not have any marked text after pad is fully loaded', function(done) {
-      var inner$ = helper.padInner$;
-
       // it takes some time for marks to be removed, so wait for it
       helper.waitFor(function() {
-        var $preCommentTextMarked = inner$('.' + markClass);
+        var $preCommentTextMarked = getPreCommentTextMarked();
         return $preCommentTextMarked.length === 0;
       }).done(done);
     });
@@ -195,10 +180,8 @@ describe('ep_comments_page - Pre-comment text mark', function() {
     });
 
     it('keeps marked text', function(done) {
-      var inner$ = helper.padInner$;
-
       // verify if text was marked with pre-comment class
-      var $preCommentTextMarked = inner$('.' + markClass);
+      var $preCommentTextMarked = getPreCommentTextMarked();
       expect($preCommentTextMarked.length).to.be(1);
       expect($preCommentTextMarked.text()).to.be(firstLineText);
 
@@ -217,5 +200,10 @@ describe('ep_comments_page - Pre-comment text mark', function() {
       // make sure form is closed before we start
       utils.closeModal('#newComment', openCommentForm);
     }
+  }
+
+  var getPreCommentTextMarked = function() {
+    var markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
+    return helper.padInner$('.' + markClass);
   }
 });


### PR DESCRIPTION
Create a module (`lineChangeEventTriggerer.js`) to calculate the top-most line number that was changed on each batch of pad changes, and trigger a unique event with that number for other plugins to use.

This avoid having the same code to calculate that line number, duplicated around several plugins. Besides removing some lines of code, we are also more efficient with these changes.

This is part of the fixes for bug https://trello.com/c/SgiGE4V0/1377.