### PR TITLE
Design/Comments Float Window

### DIFF
--- a/static/css/commentDialog.css
+++ b/static/css/commentDialog.css
@@ -27,7 +27,6 @@
 .comment-description-body {
   font-family: 'Roboto', sans-serif;
   font-weight: 300;
-  color: #000000; /* $COLOR_0 */
 
   margin-top: 5px; /* margin of comment while it's not being edited */
 }

--- a/static/css/commentDialog.css
+++ b/static/css/commentDialog.css
@@ -29,6 +29,8 @@
   font-weight: 300;
 
   margin-top: 5px; /* margin of comment while it's not being edited */
+  white-space: normal;
+  word-break: break-word;
 }
 
 .ui-dialog-buttonset button:hover,

--- a/static/css/dialog-dark.css
+++ b/static/css/dialog-dark.css
@@ -20,7 +20,8 @@
 }
 
 /* form fields */
-.theme-dark .ui-dialog input {
+.theme-dark .ui-dialog input,
+.theme-dark .ui-dialog textarea {
   color: #A0A2A6; /* color 160 */
 }
 .theme-dark .ui-dialog textarea::placeholder {

--- a/static/css/dialog-dark.css
+++ b/static/css/dialog-dark.css
@@ -45,3 +45,6 @@ overwrite autofill default:
   border: 1px solid #414246; /* color 65 */ /* [3] */
 }
 
+.theme-dark .ui-dialog .comment-description-body {
+  color: #A0A2A6; /* color 160 */
+}

--- a/static/css/dialog-light.css
+++ b/static/css/dialog-light.css
@@ -20,7 +20,8 @@
 }
 
 /* form fields */
-.theme-light .ui-dialog input {
+.theme-light .ui-dialog input,
+.theme-light .ui-dialog textarea {
   color: #64666A; /* color 100 */
 }
 .theme-light .ui-dialog textarea::placeholder {

--- a/static/css/dialog-light.css
+++ b/static/css/dialog-light.css
@@ -45,3 +45,6 @@ overwrite autofill default:
   border: 1px solid #EAEBED; /* color 235 */ /* [3] */
 }
 
+.theme-light .ui-dialog .comment-description-body {
+  color: #000000; /* $COLOR_0 */
+}

--- a/static/css/dialog.css
+++ b/static/css/dialog.css
@@ -42,6 +42,7 @@
 
 /* margin between dialog content and buttons row */
 .ui-dialog .buttons-row {
+  height: 20px;
   margin-top: 10px;
 }
 


### PR DESCRIPTION
This PR:

1. Sets theme colors for textareas and comments description;
2. Break lines of comments and replies:
![1n2-is](https://user-images.githubusercontent.com/31015005/50657538-eba07180-0f7d-11e9-96d6-34872534e8a3.png)
![1n2-was](https://user-images.githubusercontent.com/31015005/50657539-ec390800-0f7d-11e9-97c3-f99e867af640.png)

3.
![Uploading 3-is.png…]()
![3-was](https://user-images.githubusercontent.com/31015005/50657560-fe1aab00-0f7d-11e9-8396-5167a7e8e599.png)

Trello cards
1. https://trello.com/c/3Ybkvqhs/1615-p3coment%C3%A1rios-melhorar-cor-da-fonte-no-texto-dos-coment%C3%A1rio-no-tema-escuro

2. https://trello.com/c/4g3albAo/1619-p3coment%C3%A1rios-evitar-que-o-texto-dos-coment%C3%A1rios-passe-do-container-overflow

3.https://trello.com/c/9Ug87k13/1645-p3coment%C3%A1rios-evitar-que-bot%C3%B5es-do-reply-sendo-editado-ocupem-o-mesmo-espa%C3%A7o-do-nome-do-dono-do-pr%C3%B3ximo-reply
