### PR TITLE
Design/ Missing margin of Comment Dialog

### DIFF
--- a/static/css/dialog.css
+++ b/static/css/dialog.css
@@ -43,7 +43,7 @@
 /* margin between dialog content and buttons row */
 .ui-dialog .buttons-row {
   height: 20px;
-  margin-top: 10px;
+  margin: 5px 0;
 }
 
 /* overwrite round corner style shown by Chrome v62 on buttons */


### PR DESCRIPTION
This PR avoids buttons of a reply being editted to be next to the new reply textarea

It was:
![was](https://user-images.githubusercontent.com/31015005/54851192-e672d900-4cc7-11e9-98be-605b261a1cbe.png)

It is:
![is](https://user-images.githubusercontent.com/31015005/54851198-e8d53300-4cc7-11e9-9b2f-d677c57e09df.png)

Related Trello Card:
https://trello.com/c/geIzFtYc/1668-p3coment%C3%A1riosflutuante-espa%C3%A7o-entre-o-%C3%BAltimo-reply-sendo-editado-e-a-barra-para-responder