### PR TITLE
[refactor] Does not handle shortcuts for non-ScriptDocument pads

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -2,7 +2,7 @@
   "parts": [
     {
       "name":"comments_page",
-      "pre": ["ep_etherpad-lite/webaccess", "ep_page_view/page_view"],
+      "pre": ["ep_etherpad-lite/webaccess", "ep_script_elements/preLoader", "ep_page_view/page_view"],
       "post": ["ep_etherpad-lite/static"],
       "client_hooks": {
         "handleClientMessage_ACCEPT_COMMIT": "ep_comments_page/static/js/index",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -21,7 +21,6 @@ var sceneMarkVisibility = require('ep_script_scene_marks/static/js/sceneMarkVisi
 var commentInfoDialog = require('./commentInfoDialog');
 var textMarkInfoDialog = require('./textMarkInfoDialog');
 var selectLine = require('./selectLine');
-var padType = require('ep_script_elements/static/js/padType');
 
 var COMMENT_PREFIX_KEY = 'comment-c-';
 var REPLY_PREFIX_KEY = 'comment-reply-';
@@ -360,7 +359,6 @@ exports.postAceInit = function(hook, context) {
   var thisPlugin                      = pad.plugins.ep_comments_page;
   thisPlugin.api                      = api.init();
   thisPlugin.fakeIdsMapper            = fakeIdsMapper.init()
-  thisPlugin.padType                  = padType.init();
 
   // TODO: we should return an object in this module following the way other
   // modules do

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -21,6 +21,7 @@ var sceneMarkVisibility = require('ep_script_scene_marks/static/js/sceneMarkVisi
 var commentInfoDialog = require('./commentInfoDialog');
 var textMarkInfoDialog = require('./textMarkInfoDialog');
 var selectLine = require('./selectLine');
+var padType = require('ep_script_elements/static/js/padType');
 
 var COMMENT_PREFIX_KEY = 'comment-c-';
 var REPLY_PREFIX_KEY = 'comment-reply-';
@@ -359,6 +360,7 @@ exports.postAceInit = function(hook, context) {
   var thisPlugin                      = pad.plugins.ep_comments_page;
   thisPlugin.api                      = api.init();
   thisPlugin.fakeIdsMapper            = fakeIdsMapper.init()
+  thisPlugin.padType                  = padType.init();
 
   // TODO: we should return an object in this module following the way other
   // modules do

--- a/static/js/shortcuts.js
+++ b/static/js/shortcuts.js
@@ -1,12 +1,11 @@
 var eascUtils = require('ep_script_toggle_view/static/js/utils');
 var SHORTCUT_BASE = require('ep_script_scene_marks/static/js/constants').TEKSTO_SHORTCUT_BASE;
-var utils = require('./utils');
 
 var SHORTCUT_KEY = 'C';
 
 exports.processAceKeyEvent = function(context) {
   // handles key events only in ScriptDocument pads
-  var isScriptDocumentPad = pad.plugins.ep_comments_page.padType.isScriptDocumentPad();
+  var isScriptDocumentPad = pad.plugins.ep_script_elements.padType.isScriptDocumentPad();
   if (!isScriptDocumentPad) return false;
 
   var evt = context.evt;

--- a/static/js/shortcuts.js
+++ b/static/js/shortcuts.js
@@ -1,9 +1,14 @@
 var eascUtils = require('ep_script_toggle_view/static/js/utils');
 var SHORTCUT_BASE = require('ep_script_scene_marks/static/js/constants').TEKSTO_SHORTCUT_BASE;
+var utils = require('./utils');
 
 var SHORTCUT_KEY = 'C';
 
 exports.processAceKeyEvent = function(context) {
+  // handles key events only in ScriptDocument pads
+  var isScriptDocumentPad = pad.plugins.ep_comments_page.padType.isScriptDocumentPad();
+  if (!isScriptDocumentPad) return false;
+
   var evt = context.evt;
   var key = String.fromCharCode(evt.which);
 

--- a/static/tests/frontend/specs/shortcuts.js
+++ b/static/tests/frontend/specs/shortcuts.js
@@ -1,50 +1,83 @@
 describe('ep_comments_page - Shortcuts', function() {
   var utils = ep_comments_page_test_helper.utils;
 
-  before(function(done) {
-    utils.createPad(this, done);
-    this.timeout(60000);
-  });
-
-  it('opens dialog to add comment when user presses Cmd + Ctrl + C', function(done) {
-    utils.pressShortcutToAddCommentToLine(0, function() {
-      var $saveButton = helper.padOuter$('.comment-button--save').first();
-      expect($saveButton.is(':visible')).to.be(true);
-      done();
-    });
-  });
-
-  context('when user submits the form', function() {
-    before(function() {
-      var $commentForm = helper.padOuter$('#newComment');
-
-      // fill the comment form and submit it
-      var $commentField = $commentForm.find('textarea.comment-content');
-      $commentField.val('My comment');
-      var $submittButton = $commentForm.find('input[type=submit]');
-      $submittButton.click();
+  context('when the pad type is a ScriptDocument', function() {
+    before(function(done) {
+      utils.createPad(this, done);
+      this.timeout(60000);
     });
 
-    it('saves the comment on original selection', function(done) {
-      // wait until comment is created
-      helper.waitFor(function() {
-        return helper.padInner$('.comment').length > 0;
-      }).done(function() {
-        var firstLineText = utils.getLine(0).text();
-        var $commentedText = helper.padInner$('.comment');
-        expect($commentedText.text()).to.be(firstLineText);
+    it('opens dialog to add comment when user presses Cmd + Ctrl + C', function(done) {
+      utils.pressShortcutToAddCommentToLine(0, function() {
+        var $saveButton = helper.padOuter$('.comment-button--save').first();
+        expect($saveButton.is(':visible')).to.be(true);
         done();
       });
     });
 
-    it('unmarks text', function(done) {
-      var markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
+    context('when user submits the form', function() {
+      before(function() {
+        var $commentForm = helper.padOuter$('#newComment');
 
-      // verify if there is no text marked with pre-comment class
-      var $preCommentTextMarked = helper.padInner$('.' + markClass);
-      expect($preCommentTextMarked.length).to.be(0);
+        // fill the comment form and submit it
+        var $commentField = $commentForm.find('textarea.comment-content');
+        $commentField.val('My comment');
+        var $submittButton = $commentForm.find('input[type=submit]');
+        $submittButton.click();
+      });
 
-      done();
+      it('saves the comment on original selection', function(done) {
+        // wait until comment is created
+        helper
+          .waitFor(function() {
+            return helper.padInner$('.comment').length > 0;
+          })
+          .done(function() {
+            var firstLineText = utils.getLine(0).text();
+            var $commentedText = helper.padInner$('.comment');
+            expect($commentedText.text()).to.be(firstLineText);
+            done();
+          });
+      });
+
+      it('unmarks text', function(done) {
+        var markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
+
+        // verify if there is no text marked with pre-comment class
+        var $preCommentTextMarked = helper.padInner$('.' + markClass);
+        expect($preCommentTextMarked.length).to.be(0);
+
+        done();
+      });
+    });
+  });
+
+  context('when the pad type is a non-ScriptDocument', function() {
+    before(function(done) {
+      // mock a non-ScriptDocument padj
+      var padType = 'ANY_TYPE';
+
+      var epSEUtils = ep_script_elements_test_helper.utils;
+      epSEUtils.newPadWithType(function() {
+        // line needs to have some text on it
+        var $firstLine = helper.padInner$('div').first();
+        $firstLine.sendkeys('something');
+        helper
+          .waitFor(function() {
+            var lineNumber = helper.padInner$('div').length;
+            return lineNumber === 1;
+          })
+          .done(done);
+      }, padType);
+      this.timeout(60000);
+    });
+
+    it('does not opens dialog to add comment when user presses Cmd + Ctrl + C', function(done) {
+      utils.pressShortcutToAddCommentToLine(0, function() {
+        var $saveButton = helper.padOuter$('.comment-button--save').first();
+        expect($saveButton.is(':visible')).to.be(false);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
Does not process the `Cmd + Ctrl + C` (Create Comment) shortcut for `non-ScriptDocument` pads.

Depends on https://github.com/storytouch/ep_script_elements/pull/62.
Implements part of the [card 2050](https://trello.com/c/08KTQ9HF).