### PR TITLE
[style] Standardize styles of submit button on hover

### DIFF
--- a/static/css/dialog-dark.css
+++ b/static/css/dialog-dark.css
@@ -3,9 +3,6 @@
   box-shadow: 0.5px 0.5px 0.5px 0.5px #141419; /* color 20 */
   background-color: #323237; /* color 50 */
 }
-.theme-dark .ui-dialog input.button:hover {
-  color: #A0A2A6; /* color 160 */
-}
 .theme-dark .ui-dialog input.button:focus {
   color: #FFFFFF; /* color 255 */
 }

--- a/static/css/dialog-light.css
+++ b/static/css/dialog-light.css
@@ -3,9 +3,6 @@
   box-shadow: 0.5px 0.5px 0.5px 0.5px #C5C7CB; /* color 200 */
   background-color: #FFFFFF; /* color 255 */
 }
-.theme-light .ui-dialog input.button:hover {
-  color: #515256; /* color 80 */
-}
 .theme-light .ui-dialog input.button:focus {
   color: #19BBDA; /* color A */
 }

--- a/static/css/dialog.css
+++ b/static/css/dialog.css
@@ -52,6 +52,11 @@
   cursor: pointer;
 }
 
+.ui-dialog .ui-dialog-content input.button:hover {
+  color: #FFFFFF; /* color 255 */
+  background-color: #64666A; /* color 100 */
+}
+
 /* buttons Save and Cancel*/
 .ui-dialog input.button--save,
 .ui-dialog input.button--cancel {


### PR DESCRIPTION
This PR is related to [Trello Card 2476](https://trello.com/c/4RUfHneE/2476-hover-no-salvar-do-add-comment) and it adds hover styles to submit button on dialogs.

How it was:
<img width="56" alt="was" src="https://user-images.githubusercontent.com/31015005/101222994-b7ea8c80-3669-11eb-8302-c276bcc370ee.png">

Now it is:
<img width="105" alt="is" src="https://user-images.githubusercontent.com/31015005/101223001-bc16aa00-3669-11eb-9b34-20f0a59bbffa.png">
