### PR TITLE
[style] show hover styles to edit reply buttons

### DIFF
--- a/static/css/dialog.css
+++ b/static/css/dialog.css
@@ -52,7 +52,7 @@
   cursor: pointer;
 }
 
-.ui-dialog .ui-dialog-content input.button:hover {
+.ui-dialog .buttons-row input.button:hover {
   color: #FFFFFF; /* color 255 */
   background-color: #64666A; /* color 100 */
 }


### PR DESCRIPTION
This PR is related to [Trello Card 2529](https://trello.com/c/RKGsCaiN/2529-hover-nos-submits-buttons-do-salvar-e-editar-reply-n%C3%A3o-funcionam) and it fixees hover styles of edit reply buttons.

How it was:
<img width="524" alt="was" src="https://user-images.githubusercontent.com/31015005/103213179-a785a480-48eb-11eb-898a-77de5064c89f.png">

Now it is:
<img width="580" alt="is" src="https://user-images.githubusercontent.com/31015005/103221329-1de0d180-4901-11eb-9ae6-a37f495b805b.png">


