### PR TITLE
[style] Remove extra margin of comment icons column

### DIFF
--- a/static/css/commentIcon.css
+++ b/static/css/commentIcon.css
@@ -3,7 +3,6 @@
   z-index: 1;
   position: relative;
   width: 50px;
-  margin-left: 15px;
 }
 
 /* when line numbers are not visible, we need to move icons to the left */


### PR DESCRIPTION
This PR is related to [Trello Card 2551](https://trello.com/c/m8TDBTLG/2551-ajustes-visuais-texto-livre).

Remove extra margin of comment icons column, because this margin already existed at the right side of the text and we need to save space now that Courier Prime, a larger font, is implemented.

<img width="89" alt="comments-margin" src="https://user-images.githubusercontent.com/31015005/106644676-282e6500-656a-11eb-9b28-8ce4b6a71d36.png">
