### PR TITLE
[refactor] Enable comments in all pad types but TitlePage

### DIFF
--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,6 +1,5 @@
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
-var epSEShared = require('ep_script_elements/static/js/shared');
 
 var COMMENT_PREFIX_KEY = 'comment-c-';
 exports.COMMENT_PREFIX_KEY = COMMENT_PREFIX_KEY;
@@ -77,9 +76,4 @@ exports.generateCommentId = function(){
 
 exports.generateReplyId = function(){
   return REPLY_PREFIX + randomString(16);
-}
-
-exports.isCommentsEnabledOnThisPadType = function() {
-  var padType = pad.plugins.ep_script_elements.padType.getPadTypeParam();
-  return padType !== epSEShared.TITLE_PAGE_DOCUMENT_TYPE;
 }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,5 +1,6 @@
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+var epSEShared = require('ep_script_elements/static/js/shared');
 
 var COMMENT_PREFIX_KEY = 'comment-c-';
 exports.COMMENT_PREFIX_KEY = COMMENT_PREFIX_KEY;
@@ -76,4 +77,9 @@ exports.generateCommentId = function(){
 
 exports.generateReplyId = function(){
   return REPLY_PREFIX + randomString(16);
+}
+
+exports.isCommentsEnabledOnThisPadType = function() {
+  var padType = pad.plugins.ep_script_elements.padType.getPadTypeParam();
+  return padType !== epSEShared.TITLE_PAGE_DOCUMENT_TYPE;
 }

--- a/static/js/shortcuts.js
+++ b/static/js/shortcuts.js
@@ -1,13 +1,13 @@
 var eascUtils = require('ep_script_toggle_view/static/js/utils');
 var SHORTCUT_BASE = require('ep_script_scene_marks/static/js/constants').TEKSTO_SHORTCUT_BASE;
 
-var shared = require('./shared');
+var utils = require('./utils');
 
 var SHORTCUT_KEY = 'C';
 
 exports.processAceKeyEvent = function(context) {
   // handles key events only on pads type where comments are enabled
-  if (!shared.isCommentsEnabledOnThisPadType()) return false;
+  if (!utils.isCommentsEnabledOnThisPadType()) return false;
 
   var evt = context.evt;
   var key = String.fromCharCode(evt.which);

--- a/static/js/shortcuts.js
+++ b/static/js/shortcuts.js
@@ -1,12 +1,13 @@
 var eascUtils = require('ep_script_toggle_view/static/js/utils');
 var SHORTCUT_BASE = require('ep_script_scene_marks/static/js/constants').TEKSTO_SHORTCUT_BASE;
 
+var shared = require('./shared');
+
 var SHORTCUT_KEY = 'C';
 
 exports.processAceKeyEvent = function(context) {
-  // handles key events only in ScriptDocument pads
-  var isScriptDocumentPad = pad.plugins.ep_script_elements.padType.isScriptDocumentPad();
-  if (!isScriptDocumentPad) return false;
+  // handles key events only on pads type where comments are enabled
+  if (!shared.isCommentsEnabledOnThisPadType()) return false;
 
   var evt = context.evt;
   var key = String.fromCharCode(evt.which);

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,6 +1,7 @@
 var _ = require('ep_etherpad-lite/static/js/underscore');
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var smUtils = require('ep_script_scene_marks/static/js/utils');
+var seShared = require('ep_script_elements/static/js/shared');
 
 exports.LINE_CHANGED_EVENT = 'LINE_CHANGED_EVENT';
 exports.OPEN_NEW_COMMENT_MODAL_EVENT = 'OPEN_NEW_COMMENT_MODAL_EVENT';
@@ -135,4 +136,9 @@ exports.replaceDialogContentWith = function($template, dialog, selector) {
   var $currentContent = dialog.$content.find(selectorId);
   var $newContent = $template.find(selectorId);
   $currentContent.replaceWith($newContent);
+}
+
+exports.isCommentsEnabledOnThisPadType = function() {
+  var padType = pad.plugins.ep_script_elements.padType.getPadTypeParam();
+  return padType !== seShared.TITLE_PAGE_DOCUMENT_TYPE;
 }

--- a/static/tests/frontend/specs/shortcuts.js
+++ b/static/tests/frontend/specs/shortcuts.js
@@ -1,61 +1,58 @@
 describe('ep_comments_page - Shortcuts', function() {
   var utils = ep_comments_page_test_helper.utils;
 
-  context('when the pad type is a ScriptDocument', function() {
-    before(function(done) {
-      utils.createPad(this, done);
-      this.timeout(60000);
-    });
+  before(function(done) {
+    utils.createPad(this, done);
+    this.timeout(60000);
+  });
 
-    it('opens dialog to add comment when user presses Cmd + Ctrl + C', function(done) {
-      utils.pressShortcutToAddCommentToLine(0, function() {
-        var $saveButton = helper.padOuter$('.comment-button--save').first();
-        expect($saveButton.is(':visible')).to.be(true);
-        done();
-      });
-    });
-
-    context('when user submits the form', function() {
-      before(function() {
-        var $commentForm = helper.padOuter$('#newComment');
-
-        // fill the comment form and submit it
-        var $commentField = $commentForm.find('textarea.comment-content');
-        $commentField.val('My comment');
-        var $submittButton = $commentForm.find('input[type=submit]');
-        $submittButton.click();
-      });
-
-      it('saves the comment on original selection', function(done) {
-        // wait until comment is created
-        helper
-          .waitFor(function() {
-            return helper.padInner$('.comment').length > 0;
-          })
-          .done(function() {
-            var firstLineText = utils.getLine(0).text();
-            var $commentedText = helper.padInner$('.comment');
-            expect($commentedText.text()).to.be(firstLineText);
-            done();
-          });
-      });
-
-      it('unmarks text', function(done) {
-        var markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
-
-        // verify if there is no text marked with pre-comment class
-        var $preCommentTextMarked = helper.padInner$('.' + markClass);
-        expect($preCommentTextMarked.length).to.be(0);
-
-        done();
-      });
+  it('opens dialog to add comment when user presses Cmd + Ctrl + C', function(done) {
+    utils.pressShortcutToAddCommentToLine(0, function() {
+      var $saveButton = helper.padOuter$('.comment-button--save').first();
+      expect($saveButton.is(':visible')).to.be(true);
+      done();
     });
   });
 
-  context('when the pad type is a non-ScriptDocument', function() {
+  context('when user submits the form', function() {
+    before(function() {
+      var $commentForm = helper.padOuter$('#newComment');
+
+      // fill the comment form and submit it
+      var $commentField = $commentForm.find('textarea.comment-content');
+      $commentField.val('My comment');
+      var $submittButton = $commentForm.find('input[type=submit]');
+      $submittButton.click();
+    });
+
+    it('saves the comment on original selection', function(done) {
+      // wait until comment is created
+      helper
+        .waitFor(function() {
+          return helper.padInner$('.comment').length > 0;
+        })
+        .done(function() {
+          var firstLineText = utils.getLine(0).text();
+          var $commentedText = helper.padInner$('.comment');
+          expect($commentedText.text()).to.be(firstLineText);
+          done();
+        });
+    });
+
+    it('unmarks text', function(done) {
+      var markClass = helper.padChrome$.window.pad.preTextMarkers.comment.markAttribName;
+
+      // verify if there is no text marked with pre-comment class
+      var $preCommentTextMarked = helper.padInner$('.' + markClass);
+      expect($preCommentTextMarked.length).to.be(0);
+
+      done();
+    });
+  });
+
+  context('when the pad type is a TitlePage', function() {
     before(function(done) {
-      // mock a non-ScriptDocument padj
-      var padType = 'ANY_TYPE';
+      var padType = 'TitlePageDocument';
 
       var epSEUtils = ep_script_elements_test_helper.utils;
       epSEUtils.newPadWithType(function() {


### PR DESCRIPTION
This PR enables creating comments by keyboard shortcuts in all pad types, except in Title Pages.

Implements the [card 2571](https://trello.com/c/wa4OK2kO).